### PR TITLE
Fix 404

### DIFF
--- a/install/admin/admin_helper_route.php
+++ b/install/admin/admin_helper_route.php
@@ -1,8 +1,6 @@
 <?
-$bitrixPath = $_SERVER["DOCUMENT_ROOT"] . "/bitrix/modules/digitalwand.admin_helper/admin/route.php";
-$localPath = $_SERVER["DOCUMENT_ROOT"] . "/local/modules/digitalwand.admin_helper/admin/route.php";
-
-if(!@include_once($bitrixPath) AND !@include_once($localPath) ){
-    include $_SERVER['DOCUMENT_ROOT'] . '/bitrix/admin/404.php';
+if (!@include_once $_SERVER["DOCUMENT_ROOT"] . "/bitrix/modules/digitalwand.admin_helper/admin/route.php") {
+    if (!@include_once $_SERVER["DOCUMENT_ROOT"] . "/local/modules/digitalwand.admin_helper/admin/route.php") {
+        include $_SERVER['DOCUMENT_ROOT'] . '/bitrix/admin/404.php';
+    }
 }
-?>


### PR DESCRIPTION
В продолжение #22 

Если модуль был установлен `/bitrix/`, получаем 404 ошибку в админке на `/bitrix/admin/admin_helper_route.php`.

Старый вариант кода выполняется не так, как задумывалось:

``` php
if (!@include_once($bitrixPath) AND !@include_once($localPath)) {
    include $_SERVER['DOCUMENT_ROOT'] . '/bitrix/admin/404.php';
}
```

`include_once` это не вызов функции, а выражение. И когда модуль установлен в `/bitrix/` порядок выполнения был таким:

``` php
include_once $localPath;
include_once $bitrixPath AND !false;
```

Что приводит к

```
Warning: include_once(): Failed opening '1' for inclusion (include_path='.') in /bitrix/admin/admin_helper_route.php on line 5
```
