### PR TITLE
Убрал редиректы после групповых операций и операций со строками в списке

### DIFF
--- a/lib/helper/AdminListHelper.php
+++ b/lib/helper/AdminListHelper.php
@@ -242,8 +242,6 @@ abstract class AdminListHelper extends AdminBaseHelper
 						$params['ID'] = $element[$sectionField];
 					}
 				}
-
-				LocalRedirect($listHelperClass::getUrl($params));
 			}
 		}
 
@@ -532,7 +530,6 @@ abstract class AdminListHelper extends AdminBaseHelper
 						break;
 					}
 				}
-				LocalRedirect($listHelperClass::getUrl($params));
 			}
 			else {
 				$this->addErrors(Loc::getMessage('DIGITALWAND_ADMIN_HELPER_LIST_DELETE_FORBIDDEN'));
@@ -553,7 +550,6 @@ abstract class AdminListHelper extends AdminBaseHelper
 				foreach ($IDs as $id) {
 					$sectionClassName::delete($id);
 				}
-				LocalRedirect($listHelperClass::getUrl($params));
 			}
 			else {
 				$this->addErrors(Loc::getMessage('DIGITALWAND_ADMIN_HELPER_LIST_DELETE_FORBIDDEN'));


### PR DESCRIPTION
1. Обработка групповых операций и операций со строками списка происходит в конструкторе класса `AdminListHelper`, до выборки и формирования списка.
2. URL запросов групповых операций и операций со строками формируется с параметрами, которые в ответе возвращаю только контент списка.

Алгоритм без редиректа:
- Сначала в конструкторе происходит удаление/редактирование записей списка.
- Потом с учетом этих изменений формируется выборка и формируется список.
- Далее контент этого списка (без подключения `header` и `footer`) возвращается в ответе.

Указанные выше редиректы фактически возвращают то же самое, что вернул бы запрос операции после внесения изменений в конструкторе.

При работе по `HTTPS` не на стандартном 443 порту эти редиректы мешают обновлению списка, т.к. битрикс неверно определяет протокол и возвращает ответ по `HTTP`, и браузер этот ответ не пускает, ругаясь на смешанное содержимое `HTTPS`
