### PR TITLE
Исправление ошибки в виджете привязки к ORM сущности

### DIFF
--- a/lib/widget/OrmElementWidget.php
+++ b/lib/widget/OrmElementWidget.php
@@ -187,7 +187,7 @@ class OrmElementWidget extends NumberWidget
                 'type="text">' +
                 '<input type="button"' +
                 'value="..."' +
-                'onClick="jsUtils.OpenWindow(<?=$popupUrl?>, <?=$windowWidth?>, <?=$windowHeight?>);">' +
+                'onClick="jsUtils.OpenWindow(\'<?=$popupUrl?>\', <?=$windowWidth?>, <?=$windowHeight?>);">' +
                 '&nbsp;<span id="sp_<?=md5($name)?>_{{field_id}}" >{{element_title}}</span>'
             );
             <?


### PR DESCRIPTION
При использовании виджета привязки к ORM сущности в множественном режим, заметил ошибку "Uncaught SyntaxError: Invalid regular expression flags".
Поправил ошибку.
