### PR TITLE
Исправление ошибки в виджете FileWidget

### DIFF
--- a/lib/widget/FileWidget.php
+++ b/lib/widget/FileWidget.php
@@ -182,8 +182,6 @@ class FileWidget extends HelperWidget
      */
     public function processEditAction()
     {
-        parent::processEditAction();
-        
         if ($this->getSettings('MULTIPLE')) {
             if ($this->getSettings('READONLY') === true) {
                 //удаляем все добавленные файлы в режиме только для чтения
@@ -310,6 +308,7 @@ class FileWidget extends HelperWidget
 
             $this->saveFile($name, $path, $type, $description);
         }
+        parent::processEditAction();
     }
 
     protected function saveFile($name, $path, $type = false, $description = null)


### PR DESCRIPTION
Если у виджета включить "флаг" REQUIRED, то не удаётся сохранить значение поля, т.к. всё время возникает ошибка типа: "Обязательное поле "#NAME#" не заполнено".
Т.к. проверка наличия значения вызывается раньше чем сохраняется сам файл и его id записывается в поле (метод $this->saveFile()).
Поправил данную ошибку.
