### PR TITLE
Корректное удаление сущностей с составными первичными ключами

### DIFF
--- a/lang/ru/lib/helper/AdminListHelper.php
+++ b/lang/ru/lib/helper/AdminListHelper.php
@@ -13,3 +13,4 @@ $MESS['DIGITALWAND_ADMIN_HELPER_LIST_SECTION_DELETE'] = 'Удалить разд
 $MESS['DIGITALWAND_ADMIN_HELPER_LIST_SELECT'] = 'Выбрать';
 $MESS['DIGITALWAND_ADMIN_HELPER_LIST_DELETE_FORBIDDEN'] = 'Не хватает прав доступа для удаления элемента';
 $MESS['DIGITALWAND_ADMIN_HELPER_LIST_WRITE_FORBIDDEN'] = 'Не хватает прав доступа для изменения элемента';
+$MESS['DIGITALWAND_ADMIN_HELPER_LIST_SECTION_HELPER_NOT_FOUND'] = 'Хелпер для раздела не найден';

--- a/lib/helper/AdminEditHelper.php
+++ b/lib/helper/AdminEditHelper.php
@@ -171,13 +171,13 @@ abstract class AdminEditHelper extends AdminBaseHelper
 
 			$id = isset($_REQUEST[$this->pk()]) ? $_REQUEST[$this->pk()] : null;
 
-			if (!$this->data && !is_null($id)) {
+			if ($this->data === false && !is_null($id)) {
 				$this->show404();
 			}
 
 			if (isset($_REQUEST['action']) || isset($_REQUEST['action_button'])) {
 				$action = isset($_REQUEST['action']) ? $_REQUEST['action'] : $_REQUEST['action_button'];
-				$this->customActions($action, $id);
+				$this->customActions($action, $this->getPk());
 			}
 		}
 

--- a/lib/helper/AdminListHelper.php
+++ b/lib/helper/AdminListHelper.php
@@ -872,7 +872,7 @@ abstract class AdminListHelper extends AdminBaseHelper
 		}
 		else // Обычный вывод элементов без использования разделов
 		{
-            $this->totalRowsCount = $className::getCount($this->arFilter);
+            $this->totalRowsCount = $className::getCount($this->getElementsFilter($this->arFilter));
             $res = $this->getData($className, $this->arFilter, $listSelect, $sort, $raw);
             $res = new \CAdminResult($res, $this->getListTableID());
 			$this->customNavStart($res);
@@ -1027,7 +1027,7 @@ abstract class AdminListHelper extends AdminBaseHelper
 		$sectionSort = array();
 		$limitData = $this->getLimits();
 		// добавляем к общему количеству элементов количество разделов
-		$this->totalRowsCount = $sectionModel::getCount($sectionFilter);
+		$this->totalRowsCount = $sectionModel::getCount($this->getSectionsFilter($sectionFilter));
 		foreach ($sort as $field => $direction) {
 			if (in_array($field, $sectionsVisibleColumns)) {
 				$sectionSort[$field] = $direction;
@@ -1065,7 +1065,7 @@ abstract class AdminListHelper extends AdminBaseHelper
 		$elementFilter = $this->arFilter;
 		$elementFilter[$elementEditHelperClass::getSectionField()] = $_GET['ID'];
 		// добавляем к общему количеству элементов количество элементов
-		$this->totalRowsCount += $elementModel::getCount($elementFilter);
+		$this->totalRowsCount += $elementModel::getCount($this->getElementsFilter($elementFilter));
 
 		// возвращае данные без элементов если разделы занимают всю страницу выборки
 		if (!empty($returnData) && $limitData[0] == 0 && $limitData[1] == $this->totalRowsCount) {

--- a/lib/helper/AdminListHelper.php
+++ b/lib/helper/AdminListHelper.php
@@ -262,9 +262,9 @@ abstract class AdminListHelper extends AdminBaseHelper
 
 	/**
 	 * Подготавливает переменные, используемые для инициализации списка.
-     *
-     * - добавляет поля в список фильтра только если FILTER не задано false по умолчанию для виджета и поле не является
-     * полем связи сущностью разделов
+	 *
+	 * - добавляет поля в список фильтра только если FILTER не задано false по умолчанию для виджета и поле не является
+	 * полем связи сущностью разделов
 	 */
 	protected function prepareAdminVariables()
 	{
@@ -281,10 +281,10 @@ abstract class AdminListHelper extends AdminBaseHelper
 			$widget = $this->createWidgetForField($code);
 
 			if (
-                ($sectionField != $code && $widget->getSettings('FILTER') !==false)
-                &&
-                ((isset($settings['FILTER']) AND $settings['FILTER'] != false) OR !isset($settings['FILTER']))
-            ) {
+				($sectionField != $code && $widget->getSettings('FILTER') !==false)
+				&&
+				((isset($settings['FILTER']) AND $settings['FILTER'] != false) OR !isset($settings['FILTER']))
+			) {
 
 				$this->setContext(AdminListHelper::OP_ADMIN_VARIABLES_FILTER);
 				$filterVarName = 'find_' . $code;
@@ -398,10 +398,10 @@ abstract class AdminListHelper extends AdminBaseHelper
 
 	/**
 	 * Подготавливает массив с настройками контекстного меню. По-умолчанию добавлена кнопка "создать элемент".
-     *
+	 *
 	 * @see $contextMenu
-     *
-     * @api
+	 *
+	 * @api
 	 */
 	protected function getContextMenu()
 	{
@@ -465,16 +465,16 @@ abstract class AdminListHelper extends AdminBaseHelper
 
 	/**
 	 * Возвращает массив с настройками групповых действий над списком.
-     *
-     * @return array
-     *
+	 *
+	 * @return array
+	 *
 	 * @api
 	 */
 	protected function getGroupActions()
 	{
 		$result = array();
 
-        if (!$this->isPopup()) {
+		if (!$this->isPopup()) {
 			if ($this->hasDeleteRights()) {
 				$result = array('delete' => Loc::getMessage("DIGITALWAND_ADMIN_HELPER_LIST_DELETE"));
 			}
@@ -488,8 +488,8 @@ abstract class AdminListHelper extends AdminBaseHelper
 	 *
 	 * @param array $IDs
 	 * @param string $action
-     *
-     * @api
+	 *
+	 * @api
 	 */
 	protected function groupActions($IDs, $action)
 	{
@@ -690,7 +690,7 @@ abstract class AdminListHelper extends AdminBaseHelper
 	 * Является ли список всплывающим окном для выбора элементов из списка.
 	 * В этой версии не должно быть операций удаления/перехода к редактированию.
 	 *
-     * @return boolean
+	 * @return boolean
 	 */
 	public function isPopup()
 	{
@@ -701,31 +701,31 @@ abstract class AdminListHelper extends AdminBaseHelper
 	 * Функция определяет js-функцию для двойонго клика по строке.
 	 * Вызывается в том случае, если окно открыто в режиме попапа.
 	 *
-     * @api
+	 * @api
 	 */
 	protected function genPopupActionJS()
 	{
 		$this->popupClickFunctionCode = '<script>
-            function ' . $this->popupClickFunctionName . '(data){
-                var input = window.opener.document.getElementById("' . $this->fieldPopupResultName . '[' . $this->fieldPopupResultIndex . ']");
-                if(!input)
-                    input = window.opener.document.getElementById("' . $this->fieldPopupResultName . '");
-                if(input)
-                {
-                    input.value = data.ID;
-                    if (window.opener.BX)
-                        window.opener.BX.fireEvent(input, "change");
-                }
-                var span = window.opener.document.getElementById("sp_' . md5($this->fieldPopupResultName) . '_' . $this->fieldPopupResultIndex . '");
-                if(!span)
-                    span = window.opener.document.getElementById("sp_' . $this->fieldPopupResultName . '");
-                if(!span)
-                    span = window.opener.document.getElementById("' . $this->fieldPopupResultName . '_link");
-                if(span)
-                    span.innerHTML = data["' . $this->fieldPopupResultElTitle . '"];
-                window.close();
-            }
-        </script>';
+			function ' . $this->popupClickFunctionName . '(data){
+				var input = window.opener.document.getElementById("' . $this->fieldPopupResultName . '[' . $this->fieldPopupResultIndex . ']");
+				if(!input)
+					input = window.opener.document.getElementById("' . $this->fieldPopupResultName . '");
+				if(input)
+				{
+					input.value = data.ID;
+					if (window.opener.BX)
+						window.opener.BX.fireEvent(input, "change");
+				}
+				var span = window.opener.document.getElementById("sp_' . md5($this->fieldPopupResultName) . '_' . $this->fieldPopupResultIndex . '");
+				if(!span)
+					span = window.opener.document.getElementById("sp_' . $this->fieldPopupResultName . '");
+				if(!span)
+					span = window.opener.document.getElementById("' . $this->fieldPopupResultName . '_link");
+				if(span)
+					span.innerHTML = data["' . $this->fieldPopupResultElTitle . '"];
+				window.close();
+			}
+		</script>';
 	}
 
 	/**
@@ -877,9 +877,9 @@ abstract class AdminListHelper extends AdminBaseHelper
 		}
 		else // Обычный вывод элементов без использования разделов
 		{
-            $this->totalRowsCount = $className::getCount($this->getElementsFilter($this->arFilter));
-            $res = $this->getData($className, $this->arFilter, $listSelect, $sort, $raw);
-            $res = new \CAdminResult($res, $this->getListTableID());
+			$this->totalRowsCount = $className::getCount($this->getElementsFilter($this->arFilter));
+			$res = $this->getData($className, $this->arFilter, $listSelect, $sort, $raw);
+			$res = new \CAdminResult($res, $this->getListTableID());
 			$this->customNavStart($res);
 			// отключаем отображение всех элементов, если установлено св-во
 			$res->bShowAll = $this->showAll;
@@ -889,9 +889,9 @@ abstract class AdminListHelper extends AdminBaseHelper
 				list($link, $name) = $this->getRow($data);
 				$row = $this->list->AddRow($data[$this->pk()], $data, $link, $name);
 				foreach ($this->fields as $code => $settings) {
-                    if(in_array($code, $listSelect)) {
-                        $this->addRowCell($row, $code, $data);
-                    }
+					if(in_array($code, $listSelect)) {
+						$this->addRowCell($row, $code, $data);
+					}
 				}
 				$row->AddActions($this->getRowActions($data));
 			}
@@ -985,7 +985,7 @@ abstract class AdminListHelper extends AdminBaseHelper
 
 	/**
 	 * Получение смешанного списка из разделов и элементов.
-     *
+	 *
 	 * @param $sectionsVisibleColumns
 	 * @param $elementVisibleColumns
 	 * @param $sort
@@ -997,31 +997,31 @@ abstract class AdminListHelper extends AdminBaseHelper
 		$sectionEditHelperClass = $this->getHelperClass(AdminSectionEditHelper::className());
 		$elementEditHelperClass = $this->getHelperClass(AdminEditHelper::className());
 		$sectionField = $sectionEditHelperClass::getSectionField();
-        $sectionId = $_GET['SECTION_ID'] ? $_GET['SECTION_ID'] : $_GET['ID'];
+		$sectionId = $_GET['SECTION_ID'] ? $_GET['SECTION_ID'] : $_GET['ID'];
 		$returnData = array();
-        /**
-         * @var DataManager $sectionModel
-         */
+		/**
+		 * @var DataManager $sectionModel
+		 */
 		$sectionModel = $sectionEditHelperClass::getModel();
 		$sectionFilter = array();
 
-        // добавляем из фильтра те поля которые есть у разделов
-        foreach ($this->arFilter as $field => $value) {
-            $fieldName = $this->escapeFilterFieldName($field);
+		// добавляем из фильтра те поля которые есть у разделов
+		foreach ($this->arFilter as $field => $value) {
+			$fieldName = $this->escapeFilterFieldName($field);
 
-            if(!empty($this->tableColumnsMap[$fieldName])) {
-                $field = str_replace($fieldName, $this->tableColumnsMap[$fieldName], $field);
-                $fieldName = $this->tableColumnsMap[$fieldName];
-            }
+			if(!empty($this->tableColumnsMap[$fieldName])) {
+				$field = str_replace($fieldName, $this->tableColumnsMap[$fieldName], $field);
+				$fieldName = $this->tableColumnsMap[$fieldName];
+			}
 
-            if (in_array($fieldName, $sectionsVisibleColumns)) {
-                $sectionFilter[$field] = $value;
-            }
-        }
+			if (in_array($fieldName, $sectionsVisibleColumns)) {
+				$sectionFilter[$field] = $value;
+			}
+		}
 
-        $sectionFilter[$sectionField] = $sectionId;
+		$sectionFilter[$sectionField] = $sectionId;
 
-        $raw['SELECT'] = array_unique($raw['SELECT']);
+		$raw['SELECT'] = array_unique($raw['SELECT']);
 
 		// при использовании в качестве popup окна исключаем раздел из выборке
 		// что бы не было возможности сделать раздел родителем самого себя
@@ -1128,10 +1128,10 @@ abstract class AdminListHelper extends AdminBaseHelper
 	 * @param string $fieldName названия поля из фильтра
 	 * @return string название поля без без операторов фильтра
 	 */
-    protected function escapeFilterFieldName($fieldName)
-    {
-        return str_replace(array('!','<', '<=', '>', '>=', '><', '=', '%'), '', $fieldName);
-    }
+	protected function escapeFilterFieldName($fieldName)
+	{
+		return str_replace(array('!','<', '<=', '>', '>=', '><', '=', '%'), '', $fieldName);
+	}
 
 	/**
 	 * Выполняет CDBResult::NavNext с той разницей, что общее количество элементов берется не из count($arResult),
@@ -1178,12 +1178,12 @@ abstract class AdminListHelper extends AdminBaseHelper
 
 	/**
 	 * Преобразует данные строки, перед тем как добавлять их в список.
-     *
+	 *
 	 * @param $data
 	 *
-     * @see AdminListHelper::getList()
-     *
-     * @api
+	 * @see AdminListHelper::getList()
+	 *
+	 * @api
 	 */
 	protected function modifyRowData(&$data)
 	{
@@ -1191,7 +1191,7 @@ abstract class AdminListHelper extends AdminBaseHelper
 
 	/**
 	 * Настройки строки таблицы.
-     *
+	 *
 	 * @param array $data Данные текущей строки БД.
 	 * @param bool|string $class Класс хелпера через метод getUrl которого идет получение ссылки.
 	 *

--- a/lib/helper/AdminListHelper.php
+++ b/lib/helper/AdminListHelper.php
@@ -229,27 +229,6 @@ abstract class AdminListHelper extends AdminBaseHelper
 			}
 			$this->groupActions($IDs, $_REQUEST['action']);
 		}
-		/*if (isset($_REQUEST['action']) || isset($_REQUEST['action_button']) && count($this->getErrors()) == 0 ) {
-			$listHelperClass = $this->getHelperClass(AdminListHelper::className());
-			$className = $listHelperClass::getModel();
-			$id = isset($_GET['ID']) ? $_GET['ID'] : null;
-			$action = isset($_REQUEST['action']) ? $_REQUEST['action'] : $_REQUEST['action_button'];
-			if($action!='edit' && $_REQUEST['cancel'] != 'Y'){
-				$params = $_GET;
-				unset($params['action']);
-				unset($params['action_button']);
-				$this->customActions($action, $id);
-				$sectionEditHelperClass = $this->getHelperClass(AdminSectionEditHelper::className());
-
-				if ($sectionEditHelperClass) {
-					$element = $className::getById($id)->Fetch();
-					$sectionField = $listHelperClass::getSectionField();
-					if ($element[$sectionField]) {
-						$params['ID'] = $element[$sectionField];
-					}
-				}
-			}
-		}*/
 
 		if ($this->isPopup()) {
 			$this->genPopupActionJS();
@@ -1510,7 +1489,7 @@ abstract class AdminListHelper extends AdminBaseHelper
 
 	/**
 	 * Получить оставшуюся часть составного первичного ключа
-	 * 
+	 *
 	 * @param $className
 	 * @param null $sectionClassName
 	 * @param $id

--- a/lib/helper/AdminListHelper.php
+++ b/lib/helper/AdminListHelper.php
@@ -47,6 +47,11 @@ abstract class AdminListHelper extends AdminBaseHelper
 	protected $exportExcel = true;
 	/**
 	 * @var bool
+	 * Выводить в списке кол-во элементов пункт Все
+	 */
+	protected $showAll = true;
+	/**
+	 * @var bool
 	 * Является ли список всплывающим окном для выбора элементов из списка.
 	 * В этой версии не должно быть операций удаления/перехода к редактированию.
 	 */
@@ -876,8 +881,8 @@ abstract class AdminListHelper extends AdminBaseHelper
             $res = $this->getData($className, $this->arFilter, $listSelect, $sort, $raw);
             $res = new \CAdminResult($res, $this->getListTableID());
 			$this->customNavStart($res);
-            // отключаем отображение всех элементов
-            $res->bShowAll = false;
+			// отключаем отображение всех элементов, если установлено св-во
+			$res->bShowAll = $this->showAll;
 			$this->list->NavText($res->GetNavPrint(Loc::getMessage("PAGES")));
 			while ($data = $res->NavNext(false)) {
 				$this->modifyRowData($data);
@@ -1142,7 +1147,7 @@ abstract class AdminListHelper extends AdminBaseHelper
 			(int)$this->navParams['navParams']['PAGEN']
 		);
 		// отключаем отображение всех элементов
-		$res->bShowAll = false;
+		$res->bShowAll = $this->showAll;
 
 		$res->NavRecordCount = $this->totalRowsCount;
 		if ($res->NavRecordCount < 1)

--- a/lib/helper/AdminListHelper.php
+++ b/lib/helper/AdminListHelper.php
@@ -1474,6 +1474,8 @@ abstract class AdminListHelper extends AdminBaseHelper
 	}
 
 	/**
+	 * Список идентификаторов для групповых операций
+	 *
 	 * @return array
 	 */
 	protected function getIds()
@@ -1507,6 +1509,8 @@ abstract class AdminListHelper extends AdminBaseHelper
 	}
 
 	/**
+	 * Получить оставшуюся часть составного первичного ключа
+	 * 
 	 * @param $className
 	 * @param null $sectionClassName
 	 * @param $id

--- a/lib/helper/AdminListHelper.php
+++ b/lib/helper/AdminListHelper.php
@@ -1195,9 +1195,9 @@ abstract class AdminListHelper extends AdminBaseHelper
 	 * @param array $data Данные текущей строки БД.
 	 * @param bool|string $class Класс хелпера через метод getUrl которого идет получение ссылки.
 	 *
-     * @return array Возвращает ссылку на детальную страницу и её название.
+	 * @return array Возвращает ссылку на детальную страницу и её название.
 	 *
-     * @api
+	 * @api
 	 */
 	protected function getRow($data, $class = false)
 	{
@@ -1225,9 +1225,9 @@ abstract class AdminListHelper extends AdminBaseHelper
 	 * @param $code Сивольный код поля.
 	 * @param $data Данные текущей строки.
 	 *
-     * @throws Exception
+	 * @throws Exception
 	 *
-     * @see HelperWidget::generateRow()
+	 * @see HelperWidget::generateRow()
 	 */
 	protected function addRowSectionCell($row, $code, $data)
 	{
@@ -1238,8 +1238,8 @@ abstract class AdminListHelper extends AdminBaseHelper
 		}
 
 		/**
-         * @var \DigitalWand\AdminHelper\Widget\HelperWidget $widget
-         */
+		 * @var \DigitalWand\AdminHelper\Widget\HelperWidget $widget
+		 */
 		$widget = $this->sectionFields[$code]['WIDGET'];
 
 		$widget->setHelper($this);
@@ -1262,12 +1262,12 @@ abstract class AdminListHelper extends AdminBaseHelper
 	 *
 	 * @param $data Данные текущей строки.
 	 * @param $section Признак списка для раздела.
-     *
+	 *
 	 * @return array
-     *
-     * @see CAdminListRow::AddActions
-     *
-     * @api
+	 *
+	 * @see CAdminListRow::AddActions
+	 *
+	 * @api
 	 */
 	protected function getRowActions($data, $section = false)
 	{
@@ -1312,28 +1312,28 @@ abstract class AdminListHelper extends AdminBaseHelper
 
 	/**
 	 * Для каждой ячейки таблицы создаёт виджет соответствующего типа. Виджет подготавливает необходимый HTML-код
-     * для списка.
+	 * для списка.
 	 *
 	 * @param \CAdminListRow $row Объект строки списка записей.
 	 * @param string $code Сивольный код поля.
 	 * @param array $data Данные текущей строки.
 	 * @param bool $virtualCode
 	 *
-     * @throws Exception
+	 * @throws Exception
 	 *
-     * @see HelperWidget::generateRow()
+	 * @see HelperWidget::generateRow()
 	 */
 	protected function addRowCell($row, $code, $data, $virtualCode = false)
 	{
 		$widget = $this->createWidgetForField($code, $data);
 		$this->setContext(AdminListHelper::OP_ADD_ROW_CELL);
 
-        // устанавливаем виртуальный код ячейки, используется при слиянии столбцов
+		// устанавливаем виртуальный код ячейки, используется при слиянии столбцов
 		if ($virtualCode) {
 			$widget->setCode($virtualCode);
 		}
 
-        $widget->generateRow($row, $data);
+		$widget->generateRow($row, $data);
 
 		if ($virtualCode) {
 			$widget->setCode($code);
@@ -1351,18 +1351,18 @@ abstract class AdminListHelper extends AdminBaseHelper
 	 * @param array $raw
 	 *
 	 * @return Result
-     *
-     * @api
+	 *
+	 * @api
 	 */
 	protected function getData($className, $filter, $select, $sort, $raw)
 	{
-        $limits = $this->getLimits();
+		$limits = $this->getLimits();
 		$parameters = array(
 			'filter' => $this->getElementsFilter($filter),
 			'select' => $select,
 			'order' => $sort,
-            'offset' => $limits[0],
-            'limit' => $limits[1],
+			'offset' => $limits[0],
+			'limit' => $limits[1],
 		);
 
 		/** @var Result $res */
@@ -1393,33 +1393,33 @@ abstract class AdminListHelper extends AdminBaseHelper
 	 */
 	public function createFilterForm()
 	{
-        //нужно пробрасывать параметр popup в форму, если она является таковой
-        if($this->isPopup())
-        {
-            $this->additionalUrlParams['popup'] = 'Y';
-        }
+		//нужно пробрасывать параметр popup в форму, если она является таковой
+		if($this->isPopup())
+		{
+			$this->additionalUrlParams['popup'] = 'Y';
+		}
 
 		$this->setContext(AdminListHelper::OP_CREATE_FILTER_FORM);
 		print ' <form name="find_form" method="GET" action="' . static::getUrl($this->additionalUrlParams) . '?">';
 
-        $sectionHelper = $this->getHelperClass(AdminSectionEditHelper::className());
-        if($sectionHelper) {
-            $sectionsInterfaceSettings = static::getInterfaceSettings($sectionHelper::getViewName());
-            foreach($this->arFilterOpts as $code => &$name) {
-                if(!empty($this->tableColumnsMap[$code])) {
-                    $name = $sectionsInterfaceSettings['FIELDS'][$this->tableColumnsMap[$code]]['WIDGET']->getSettings('TITLE');
-                }
-            }
-        }
+		$sectionHelper = $this->getHelperClass(AdminSectionEditHelper::className());
+		if($sectionHelper) {
+			$sectionsInterfaceSettings = static::getInterfaceSettings($sectionHelper::getViewName());
+			foreach($this->arFilterOpts as $code => &$name) {
+				if(!empty($this->tableColumnsMap[$code])) {
+					$name = $sectionsInterfaceSettings['FIELDS'][$this->tableColumnsMap[$code]]['WIDGET']->getSettings('TITLE');
+				}
+			}
+		}
 
 		$oFilter = new \CAdminFilter($this->getListTableID() . '_filter', $this->arFilterOpts);
 		$oFilter->Begin();
 
 		foreach ($this->arFilterOpts as $code => $name) {
 			$widget = $this->createWidgetForField($code);
-            if($widget->getSettings('TITLE') != $this->arFilterOpts[$code]) {
-                $widget->setSetting('TITLE', $this->arFilterOpts[$code]);
-            }
+			if($widget->getSettings('TITLE') != $this->arFilterOpts[$code]) {
+				$widget->setSetting('TITLE', $this->arFilterOpts[$code]);
+			}
 			$widget->showFilterHtml();
 		}
 


### PR DESCRIPTION
Исправлена проблема удаления сущностей с составными ключами, когда возникала ошибка при валидации первичного ключа. Генерации правильного составного ключа сущности при удалении. Корректный редирект после удаления сущности в список.