### PR TITLE
fix E_WARNING

### DIFF
--- a/lib/helper/AdminEditHelper.php
+++ b/lib/helper/AdminEditHelper.php
@@ -569,7 +569,7 @@ abstract class AdminEditHelper extends AdminBaseHelper
 	 * 
      * @api
 	 */
-	protected function customActions($action, $id)
+	protected function customActions($action, $id = null)
 	{
 		if ($action == 'delete' AND !is_null($id)) {
 			$result = $this->deleteElement($id);


### PR DESCRIPTION
> Declaration of DigitalWand\AdminHelper\Helper\AdminEditHelper::customActions($action, $id) should be compatible with DigitalWand\AdminHelper\Helper\AdminBaseHelper::customActions($action, $id = NULL)