### PR TITLE
Устранена ошибка повторения предпоследнего названия поля форме фильтра

### DIFF
--- a/lib/helper/AdminListHelper.php
+++ b/lib/helper/AdminListHelper.php
@@ -1452,9 +1452,11 @@ abstract class AdminListHelper extends AdminBaseHelper
 		$sectionHelper = $this->getHelperClass(AdminSectionEditHelper::className());
 		if($sectionHelper) {
 			$sectionsInterfaceSettings = static::getInterfaceSettings($sectionHelper::getViewName());
-			foreach($this->arFilterOpts as $code => &$name) {
+			foreach($this->arFilterOpts as $code => $name) {
 				if(!empty($this->tableColumnsMap[$code])) {
-					$name = $sectionsInterfaceSettings['FIELDS'][$this->tableColumnsMap[$code]]['WIDGET']->getSettings('TITLE');
+					$newName = $sectionsInterfaceSettings['FIELDS'][$this->tableColumnsMap[$code]]['WIDGET']
+                        ->getSettings('TITLE');
+					$this->arFilterOpts[$code] = $newName;
 				}
 			}
 		}

--- a/lib/widget/HelperWidget.php
+++ b/lib/widget/HelperWidget.php
@@ -507,6 +507,11 @@ abstract class HelperWidget
                 $to = $_REQUEST['find_' . $field . '_to'];
                 if (is_a($this, 'DateWidget')) {
                     $to = date('Y-m-d 23:59:59', strtotime($to));
+                } else if (
+                        is_a($this, '\DigitalWand\AdminHelper\Widget\DateTimeWidget') &&
+                        !preg_match('/\d{2}:\d{2}:\d{2}/', $to)
+                ) {
+                    $to = date('d.m.Y 23:59:59', strtotime($to));
                 }
             }
 


### PR DESCRIPTION
В \DigitalWand\AdminHelper\Helper\AdminListHelper::$arFilterOpts попадало значение по ссылке, которое приводило к тому, что в форме фильтра последнее поле всегда принимало название предпоследнего.