### PR TITLE
Исправление бага с пустыми значениями колонок

### DIFF
--- a/lib/helper/AdminListHelper.php
+++ b/lib/helper/AdminListHelper.php
@@ -796,7 +796,7 @@ abstract class AdminListHelper extends AdminBaseHelper
 			$sectionsVisibleColumns = array();
 			foreach ($visibleColumns as $k => $v) {
 				if (isset($this->sectionFields[$v])) {
-					if(!in_array($k, $elementFields)){
+					if(!in_array($v, $elementFields)){
 						unset($visibleColumns[$k]);
 					}
 					$sectionsVisibleColumns[] = $v;


### PR DESCRIPTION
В смешанном представлении списка у элементов будут пустые колонки там, где код колонки совпадает с кодом одной из колонок разделов.