### PR TITLE
Устранена ошибка неверного формирования фильтра секции элемента при просмотре содержимого секции

### DIFF
--- a/lib/helper/AdminListHelper.php
+++ b/lib/helper/AdminListHelper.php
@@ -1115,7 +1115,7 @@ abstract class AdminListHelper extends AdminBaseHelper
 		$elementLimit = $limitData[1] - count($returnData);
 		$elementModel = static::$model;
 		$elementFilter = $this->arFilter;
-		$elementFilter[$elementEditHelperClass::getSectionField()] = $_GET['ID'];
+		$elementFilter[$elementEditHelperClass::getSectionField()] = $sectionId;
 		// добавляем к общему количеству элементов количество элементов
 		$this->totalRowsCount += $elementModel::getCount($this->getElementsFilter($elementFilter));
 


### PR DESCRIPTION
При переходе внутрь секции и попытке отфильтровать содержимое, используя форму, происходила неверная фильтрация: выводились только секции без элементов