### PR TITLE
Исправлен вывод ошибок формы редактирования в попапе публичной части

### DIFF
--- a/lib/helper/AdminEditHelper.php
+++ b/lib/helper/AdminEditHelper.php
@@ -150,6 +150,13 @@ abstract class AdminEditHelper extends AdminBaseHelper
 			}
 
 			if (isset($url)) {
+				if (defined('BX_PUBLIC_MODE') && BX_PUBLIC_MODE === 1 && $this->getErrors())
+				{
+					ob_end_clean();
+					$jsMessage = \CUtil::JSEscape(implode("\n", $this->getErrors()));
+					echo '<script>top.BX.WindowManager.Get().ShowError("' . $jsMessage . '");</script>';
+					die();
+				}
 				$this->setAppException($this->app->GetException());
 				LocalRedirect($url);
 			}

--- a/lib/helper/AdminEditHelper.php
+++ b/lib/helper/AdminEditHelper.php
@@ -150,8 +150,7 @@ abstract class AdminEditHelper extends AdminBaseHelper
 			}
 
 			if (isset($url)) {
-				if (defined('BX_PUBLIC_MODE') && BX_PUBLIC_MODE === 1 && ($errors = $this->getErrors()))
-				{
+				if (defined('BX_PUBLIC_MODE') && BX_PUBLIC_MODE === 1 && ($errors = $this->getErrors())) {
 					ob_end_clean();
 					$jsMessage = \CUtil::JSEscape(implode("\n", $errors));
 					echo '<script>top.BX.WindowManager.Get().ShowError("' . $jsMessage . '");</script>';

--- a/lib/helper/AdminEditHelper.php
+++ b/lib/helper/AdminEditHelper.php
@@ -150,10 +150,10 @@ abstract class AdminEditHelper extends AdminBaseHelper
 			}
 
 			if (isset($url)) {
-				if (defined('BX_PUBLIC_MODE') && BX_PUBLIC_MODE === 1 && $this->getErrors())
+				if (defined('BX_PUBLIC_MODE') && BX_PUBLIC_MODE === 1 && ($errors = $this->getErrors()))
 				{
 					ob_end_clean();
-					$jsMessage = \CUtil::JSEscape(implode("\n", $this->getErrors()));
+					$jsMessage = \CUtil::JSEscape(implode("\n", $errors));
 					echo '<script>top.BX.WindowManager.Get().ShowError("' . $jsMessage . '");</script>';
 					die();
 				}


### PR DESCRIPTION
На текущий момент при возникновении ошибок валидации попап закрывается, а ошибки выводятся при повторном его открытии.