### PR TITLE
Исправлена выборка runtime-полей на форме редактирования

### DIFF
--- a/lib/helper/AdminEditHelper.php
+++ b/lib/helper/AdminEditHelper.php
@@ -499,7 +499,12 @@ abstract class AdminEditHelper extends AdminBaseHelper
 	{
 		if ($this->getPk() !== null) {
 			$className = static::getModel();
-			$result = $className::getById($this->getPk());
+			$result = $className::getList(array(
+				'filter' => array(
+					$this->pk() => $this->getPk()
+				),
+				'select' => $select ?: array('*')
+			));
 
 			return $result->fetch();
 		}


### PR DESCRIPTION
Иногда требуется на форму добавить вычисляемое поле с `READONLY` виджетом.
Сейчас у таких полей нет значения на форме. Фикс добавляет их в выборку из БД.